### PR TITLE
ncippe-329--participant-id-field

### DIFF
--- a/src/components/Mocha/UploadReport.js
+++ b/src/components/Mocha/UploadReport.js
@@ -283,7 +283,7 @@ const UploadReport = () => {
             onChange={handlePatientId}
             value={patientData.patientId}
             inputProps={{
-              maxLength: 8,
+              maxLength: 20,
             }}
           />
           {patientData.notFound && <Status state="error" title="This participant is not in the system" message="Please double check the Participant ID on the hard copy of the report and re-enter it above. If this problem persists, contact the system administrator." />}


### PR DESCRIPTION
increase participant id input length to 20 characters on mocha report upload workflow
closes ncippe-329
