### PR TITLE
ncippe-523 add external link class and image

### DIFF
--- a/src/components/region/Footer/Footer.js
+++ b/src/components/region/Footer/Footer.js
@@ -129,6 +129,7 @@ const Footer = () => {
         </Grid>
         <div className={classes.tagline}>{t('footer.tagline')}</div>
       </Typography>
+      <div id="external" className="visually-hidden">{t('aria.external')}</div>
     </Container>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -98,6 +98,14 @@ figcaption {
   font-weight: bold;
 }
 
+.external {
+  display: inline-block;
+  background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"></path><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" style="fill: rgb(30, 111, 214)"></path></svg>');
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 28px;
+}
+
 sup {
   vertical-align: super;
   font-size: 60%

--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,16 @@ figcaption {
   padding-right: 28px;
 }
 
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 sup {
   vertical-align: super;
   font-size: 60%


### PR DESCRIPTION
Note: the image is embedded in the CSS as a base-64 string

There is also a ncippe-content PR to go along with this one. https://github.com/CBIIT/ncippe-content/pull/42